### PR TITLE
fix: 🐛 name parameter is required and must be a string

### DIFF
--- a/npm-packages/semantic-release-config/index.cjs
+++ b/npm-packages/semantic-release-config/index.cjs
@@ -1,7 +1,11 @@
 module.exports.createReleaseConfig = ({
   srcRoot = './',
   name = '',
-  branch = 'main',
+  branches = [
+    {
+      name: 'main',
+    },
+  ],
 }) => {
   if (!srcRoot || typeof srcRoot !== 'string') {
     throw new Error('srcRoot parameter is required and must be a string');
@@ -12,7 +16,7 @@ module.exports.createReleaseConfig = ({
     pkgRoot: srcRoot,
     tagFormat: name ? `${name}-v\${version}` : `${version}`,
     commitPaths: [`${srcRoot}/*`],
-    branch: branch,
+    branches: branches,
     plugins: [
       '@semantic-release/commit-analyzer',
       '@semantic-release/release-notes-generator',

--- a/npm-packages/semantic-release-config/index.cjs
+++ b/npm-packages/semantic-release-config/index.cjs
@@ -11,6 +11,20 @@ module.exports.createReleaseConfig = ({
     throw new Error('srcRoot parameter is required and must be a string');
   }
 
+  if (typeof name !== 'string') {
+    throw new Error('name parameter must be a string');
+  }
+
+  if (
+    !Array.isArray(branches) ||
+    !branches.length ||
+    !branches.every((b) => b.name && typeof b.name === 'string')
+  ) {
+    throw new Error(
+      'branches parameter must be a non-empty array of objects with name property',
+    );
+  }
+
   return {
     extends: 'semantic-release-npm-github-publish',
     pkgRoot: srcRoot,


### PR DESCRIPTION
https://github.com/semantic-release/semantic-release/blob/master/docs/usage/workflow-configuration.md
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
	- Updated the release configuration to allow for more complex branch definitions, enhancing flexibility for future configurations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->