### PR TITLE
fix: 🐛 the readme of installing for monorepo is old

### DIFF
--- a/npm-packages/semantic-release-config/CHANGELOG.md
+++ b/npm-packages/semantic-release-config/CHANGELOG.md
@@ -18,21 +18,8 @@
 * ✨ test could release work ([ad09588](https://github.com/zhumeisongsong/multiple-products-workspace/commit/ad09588e3bcd31e859e1e8c953563e98de538ee6))
 * ✨ update readme ([869bc43](https://github.com/zhumeisongsong/multiple-products-workspace/commit/869bc4379fcd18cb3b661460a8c2c90e4a03cc27))
 
-# [1.3.0](https://github.com/zhumeisongsong/multiple-products-workspace/compare/semantic-release-config-v1.2.2...semantic-release-config-v1.3.0) (2024-12-14)
+## [1.2.2](https://github.com/zhumeisongsong/multiple-products-workspace/compare/semantic-release-config-v1.2.1...semantic-release-config-v1.2.2) (2024-11-27)
 
-
-### Bug Fixes
-
-* 🐛 fix 1.2.3 tag is existed error ([f8f8f3c](https://github.com/zhumeisongsong/multiple-products-workspace/commit/f8f8f3c5c19c57d578fd65f119b5c1c547d85d1d))
-* 🐛 lint error by moving packgae from devdeps to deps ([3676b63](https://github.com/zhumeisongsong/multiple-products-workspace/commit/3676b63f3c2c3414779444e1dd2a15d1f9f8a3c1))
-* 🐛 test release packages ([871a581](https://github.com/zhumeisongsong/multiple-products-workspace/commit/871a581bac2fff6ce894507d5955211c6fc30014))
-* 🐛 test to deprecate semantic-release-config 1.2.3 ([696d95c](https://github.com/zhumeisongsong/multiple-products-workspace/commit/696d95ca476a7b3fa4c8fba74a2b1996ab7f823f))
-
-
-### Features
-
-* ✨ test could release work ([ad09588](https://github.com/zhumeisongsong/multiple-products-workspace/commit/ad09588e3bcd31e859e1e8c953563e98de538ee6))
-* ✨ update readme ([869bc43](https://github.com/zhumeisongsong/multiple-products-workspace/commit/869bc4379fcd18cb3b661460a8c2c90e4a03cc27))
 
 ### Bug Fixes
 

--- a/npm-packages/semantic-release-config/README.md
+++ b/npm-packages/semantic-release-config/README.md
@@ -9,15 +9,11 @@ Semantic release config for publishing NPM packages to GitHub and NPM registry. 
 - GitHub release
 - Git asset updates
 
-## Install
+## Install For Monorepo
 
 ### 1. Install related packages:
 
-`pnpm install semantic-release semantic-release-npm-github-publish @semantic-release/changelog @semantic-release/git -D`
-
-If you are using semantic-release-plus, you can install the following packages:
-
-`pnpm install semantic-release-plus -D`
+`pnpm install semantic-release semantic-release-npm-github-publish @semantic-release/changelog @semantic-release/git semantic-release-plus -D`
 
 ### 2. Install @zhumeisong/semantic-release-config:
 
@@ -27,19 +23,19 @@ If you are using semantic-release-plus, you can install the following packages:
 
 ```
 const {
-  createReleaseConfig,
+  createMonorepoReleaseConfig,
 } = require('@zhumeisong/semantic-release-config');
 
-const name = '';
-const srcRoot = './';
-const pkgRoot = 'dist/';
+const name = 'your-package-name';
+const srcRoot = './your-package-src-root';
+const pkgRoot = 'dist/your-package-pkg-root';
 const branches = [
   {
     name: 'main',
   },
 ];
 
-module.exports = createReleaseConfig({
+module.exports = createMonorepoReleaseConfig({
   name,
   srcRoot,
   pkgRoot,
@@ -49,9 +45,40 @@ module.exports = createReleaseConfig({
 
 ## Configuration Options
 
-| Option | Type | Default | Description | Examples |
-|--------|------|---------|-------------|-----------|
-| srcRoot | string | './' | The root directory containing your package.json | - './' (Current directory)<br>- './npm-packages/git-cz-config' (Nested package)<br>- './dist/npm-packages/git-cz-config' (Build directory) |
-| pkgRoot | string | 'dist/' | The root directory containing your package.json | - 'dist/' (Build directory)<br>- 'dist/npm-packages/git-cz-config' (Nested package) |
-| name | string | '' | The name of your package. Used in tag format and release message | - '' (No prefix)<br>- 'git-cz-config' (Creates tags like 'git-cz-config-v1.0.0') |
-| branches | { name: string }[] | [{ name: 'main' }] | The branches you want to release from | - [{ name: 'main' }] (Only main branch)<br>- [{ name: 'main' }, { name: 'dev' }] (Multiple branches) |
+### name
+
+The name of your package. Used in tag format and release message.
+
+type: `string`
+
+default: ``
+
+example: `@zhumeisong/semantic-release-config`
+
+### srcRoot
+
+The source directory of your package.
+
+type: `string`
+
+default: `./`
+
+example: `npm-packages/semantic-release-config`
+
+### pkgRoot
+
+The build directory of your package.
+
+type: `string`
+
+default: `dist/`
+
+example: `dist/npm-packages/semantic-release-config`
+
+### branches
+
+The branches you want to release from.
+
+type: `{ name: string }[]`
+
+default: `[{ name: 'main' }]`

--- a/npm-packages/semantic-release-config/src/monorepo-release-config.cjs
+++ b/npm-packages/semantic-release-config/src/monorepo-release-config.cjs
@@ -1,7 +1,7 @@
 module.exports.createMonorepoReleaseConfig = ({
   name = '',
   srcRoot = './',
-  pkgRoot = 'dist/',
+  pkgRoot = './dist/',
   branches = [
     {
       name: 'main',
@@ -33,7 +33,7 @@ module.exports.createMonorepoReleaseConfig = ({
   return {
     extends: 'semantic-release-npm-github-publish',
     pkgRoot: pkgRoot,
-    tagFormat: name ? `${name}-v\${version}` : `v\${version}`,
+    tagFormat:  `${name}-v\${version}`,
     commitPaths: [`${srcRoot}/*`],
     branches: branches,
     plugins: [
@@ -51,7 +51,7 @@ module.exports.createMonorepoReleaseConfig = ({
         {
           assets: [`${srcRoot}/package.json`, `${srcRoot}/CHANGELOG.md`],
           message:
-            `release(version): Release ${name ? `${name} ` : ''}` +
+            `release(version): Release ${name}` +
             '${nextRelease.version} [skip ci]\n\n${nextRelease.notes}',
         },
       ],


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced `createMonorepoReleaseConfig` method for improved monorepo configuration.
	- Updated `createReleaseConfig` method to include a new argument `pkgRoot`.

- **Bug Fixes**
	- Resolved issues related to version tagging and linting errors.

- **Documentation**
	- Updated installation and configuration instructions for monorepos in the README.
	- Enhanced clarity and structure of configuration options in the documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->