### PR TITLE
fix: 🐛 root path of github packages release config

### DIFF
--- a/github-packages/common-error-exception/release.config.cjs
+++ b/github-packages/common-error-exception/release.config.cjs
@@ -1,8 +1,8 @@
 const { createMonorepoReleaseConfig } = require('@zhumeisong/semantic-release-config');
 
 const name = 'common-error-exception';
-const srcRoot = `npm-packages/${name}`;
-const pkgRoot = `dist/npm-packages/${name}`;
+const srcRoot = `github-packages/${name}`;
+const pkgRoot = `dist/github-packages/${name}`;
 
 module.exports = createMonorepoReleaseConfig({
   name,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated package configuration paths from `npm-packages` to `github-packages` to align with new directory structure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->